### PR TITLE
Fix outdated free variables syntax

### DIFF
--- a/lib/array.cr
+++ b/lib/array.cr
@@ -127,11 +127,11 @@ class Array(T)
   end
 end
 
-def get_shape(arr : Array(Array(T)))
+def get_shape(arr : Array(Array(T))) forall T
   {arr.size, arr[0].size}
 end
 
-def get_shape(arr : Array(T))
+def get_shape(arr : Array(T)) forall T
   arr.size
 end
 


### PR DESCRIPTION
Currently the example returns this error

```
$ crystal classification_example.cr 
Error in classification_example.cr:10: instantiating 'Array(Array(Float32))#shape()'

puts "Shapes: X: #{x.shape}, y: #{y.shape}"
                     ^~~~~

in /home/hugo/gh/crystal-learn/lib/array.cr:130: undefined constant T

def get_shape(arr : Array(Array(T)))
                                ^
```